### PR TITLE
Say hello

### DIFF
--- a/.well-known/farcaster.json
+++ b/.well-known/farcaster.json
@@ -1,9 +1,4 @@
 {
-  "accountAssociation": {
-    "header": "eyJmaWQiOjE3NjUyLCJ0eXBlIjoiY3VzdG9keSIsImtleSI6IjB4RGM1QmU0Mjg2MEZBRDQ3MTFlQTQ5Nzk4QzE2RDRmMjgwQUMxMzZGMyJ9",
-    "payload": "eyJkb21haW4iOiJhcmJpdHJ1bWdhbWUudmVyY2VsLmFwcCJ9",
-    "signature": "MHhlZGQ2ZTBlMjhhNWE5MDI1NWU2OWJmY2E2ODU2ZGQwZjYwMDk4YWU2MDRkYmMzZjI3NjRkYTRjYzhhYmQ2NWNiNDFhNDgxYTEyMTNjMDYzYzllNGVmMzQzZTI4Nzg3OWUyMmIzNjcwNDU2Y2NkMjNhNDk4Y2I3ZDRjMTk5NDczZjFi"
-  },
   "frame": {
     "version": "1",
     "name": "ArbitrumTapTap",

--- a/farcaster.json
+++ b/farcaster.json
@@ -18,7 +18,7 @@
     "memecoins",
     "web3"
   ],
-  "tagline": "Tap, Earn & Mint NFTs on Arbit",
+  "tagline": "Tap, Earn & Mint NFTs on Arbitrum",
   "buttonTitle": "Play Game",
   "ogTitle": "Arbitrum Tap Tap Game",
   "ogDescription": "Tap the Arbitrum logo to earn points and unlock NFT minting opportunities on Arbitrum.",


### PR DESCRIPTION
Remove invalid `accountAssociation` from `farcaster.json` to fix signature validation errors.

The `accountAssociation` section was signed by an incorrect Farcaster account, causing an invalid signature for the domain. Since account association is optional for Farcaster Mini Apps, removing it resolves the issue without affecting functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-13607867-3e4d-4804-91ff-82af5d20407b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-13607867-3e4d-4804-91ff-82af5d20407b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

